### PR TITLE
netstandard1.5 and netcore1.1 builds.

### DIFF
--- a/AsnType.cs
+++ b/AsnType.cs
@@ -20,8 +20,11 @@ namespace SnmpSharpNet
 	/// <summary>
 	/// Base class for all ASN.1 value classes
 	/// </summary>
-	public abstract class AsnType: ICloneable
-	{
+	public abstract class AsnType
+#if !NETCOREAPP11 && !NETSTANDARD15
+        : ICloneable
+#endif
+    {
 		/// <summary>Bool true/false value type</summary>
 		public static readonly byte BOOLEAN = (byte)0x01;
 

--- a/Exception/SnmpException.cs
+++ b/Exception/SnmpException.cs
@@ -17,11 +17,13 @@ using System;
 
 namespace SnmpSharpNet
 {
-	/// <summary>
-	/// SNMP generic exception. Thrown every time SNMP specific error is encountered.
-	/// </summary>
-	[Serializable]
-	public class SnmpException : Exception
+    /// <summary>
+    /// SNMP generic exception. Thrown every time SNMP specific error is encountered.
+    /// </summary>
+#if !NETCOREAPP11 && !NETSTANDARD15
+    [Serializable]
+#endif
+    public class SnmpException : Exception
 	{
 		/// <summary>
 		/// No error

--- a/MutableByte.cs
+++ b/MutableByte.cs
@@ -43,7 +43,10 @@ namespace SnmpSharpNet
 	/// buffer.Reset(); // Erase all the data from the buffer
 	/// </code>
 	/// </remarks>
-	public class MutableByte: Object, ICloneable, IComparable<MutableByte>, IComparable<byte[]>
+	public class MutableByte: Object, IComparable<MutableByte>, IComparable<byte[]>
+#if !NETCOREAPP11 && !NETSTANDARD15
+        , ICloneable
+#endif
 	{
 		/// <summary>
 		/// Internal byte buffer

--- a/SimpleSnmp.cs
+++ b/SimpleSnmp.cs
@@ -1104,9 +1104,15 @@ namespace SnmpSharpNet
 				IPHostEntry he = null;
 				try
 				{
+#if !NETCOREAPP11 && !NETSTANDARD15
 					he = Dns.GetHostEntry(_peerName);
+#else
+                    var t = Dns.GetHostEntryAsync(_peerName);
+				    t.Wait();
+				    he = t.Result;
+#endif
 				}
-				catch(Exception ex)
+                catch (Exception ex)
 				{
 					if( ! _suppressExceptions )
 					{
@@ -1149,6 +1155,6 @@ namespace SnmpSharpNet
 		}
 
 
-		#endregion
+#endregion
 	}
 }

--- a/Snmp.cs
+++ b/Snmp.cs
@@ -20,8 +20,8 @@ namespace SnmpSharpNet
 		/// <summary>
 		/// Constructor
 		/// </summary>
-		public Snmp()
-			:base()
+		public Snmp(bool useIpv6)
+			:base(useIpv6)
 		{
 			_response = null;
 			_target = null;

--- a/SnmpSharpNet-Std.csproj
+++ b/SnmpSharpNet-Std.csproj
@@ -1,0 +1,59 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>.NET implementation of SNMP protocol</Description>
+    <AssemblyTitle>SnmpSharpNet</AssemblyTitle>
+    <VersionPrefix>1.0</VersionPrefix>
+	
+    <TargetFrameworks>netstandard1.5;net451;netcoreapp1.1</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>SnmpSharpNet</AssemblyName>
+
+    <PackageId>SnmpSharpNet</PackageId>
+    <PackageTags>snmp;netstandard;netcore;net45</PackageTags>
+    <PackageProjectUrl>https://github.com/rqx110/SnmpSharpNet</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/rqx110/SnmpSharpNet</PackageLicenseUrl>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.5' ">1.6.1</NetStandardImplicitPackageVersion>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <RootNamespace>SnmpSharpNet</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+    <Reference Include="System" />
+  </ItemGroup>
+  
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
+   	<PackageTargetFallback>$(PackageTargetFallback);net4-client</PackageTargetFallback>	 
+  </PropertyGroup>
+  
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
+    <DefineConstants>$(DefineConstants);NETSTANDARD15</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
+    <DefineConstants>$(DefineConstants);NETCOREAPP11</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
+    <PackageReference Include="Microsoft.NETCore.App">
+      <Version>1.0.1</Version>
+    </PackageReference>
+    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
+    <PackageReference Include="System.Net.Sockets" Version="4.3.0" />	
+    <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />
+  </ItemGroup>
+</Project>

--- a/SnmpSharpNet-Std.sln
+++ b/SnmpSharpNet-Std.sln
@@ -1,0 +1,26 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.9
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SnmpSharpNet-Std", "SnmpSharpNet-Std.csproj", "{49C00462-2611-43A3-9241-C02F9199D86B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{49C00462-2611-43A3-9241-C02F9199D86B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{49C00462-2611-43A3-9241-C02F9199D86B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49C00462-2611-43A3-9241-C02F9199D86B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{49C00462-2611-43A3-9241-C02F9199D86B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE4D0BF8-AB3F-4A4D-8179-BC69D886F75C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE4D0BF8-AB3F-4A4D-8179-BC69D886F75C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE4D0BF8-AB3F-4A4D-8179-BC69D886F75C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE4D0BF8-AB3F-4A4D-8179-BC69D886F75C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/TrapAgent.cs
+++ b/TrapAgent.cs
@@ -58,15 +58,19 @@ namespace SnmpSharpNet
 		/// <remarks>Destructors only purpose is to close the Socket used by the class.</remarks>
 		~TrapAgent()
 		{
-			_sock.Close();
-		}
-		/// <summary>
-		/// Send SNMP version 1 Trap notification
-		/// </summary>
-		/// <param name="packet">SNMP v1 Trap packet class</param>
-		/// <param name="peer">Manager (receiver) IP address</param>
-		/// <param name="port">Manager (receiver) UDP port number</param>
-		public void SendV1Trap(SnmpV1TrapPacket packet, IpAddress peer, int port)
+#if !NETCOREAPP11 && !NETSTANDARD15
+            _sock.Close();
+#else
+            _sock.Dispose();
+#endif
+        }
+        /// <summary>
+        /// Send SNMP version 1 Trap notification
+        /// </summary>
+        /// <param name="packet">SNMP v1 Trap packet class</param>
+        /// <param name="peer">Manager (receiver) IP address</param>
+        /// <param name="port">Manager (receiver) UDP port number</param>
+        public void SendV1Trap(SnmpV1TrapPacket packet, IpAddress peer, int port)
 		{
 			byte[] outBuffer = packet.encode();
 			_sock.SendTo(outBuffer, new IPEndPoint((IPAddress)peer, port));

--- a/TrapPdu.cs
+++ b/TrapPdu.cs
@@ -22,8 +22,11 @@ namespace SnmpSharpNet
 	/// Trap PDU for SNMP version 1 is a PDU with a unique layout requiring a dedicated class. SNMP versions
 	/// 2 and 3 use standard PDU type for V2TRAP notifications.
 	/// </remarks>
-	public class TrapPdu: AsnType, ICloneable
-	{
+	public class TrapPdu: AsnType
+#if !NETCOREAPP11 && !NETSTANDARD15
+        , ICloneable
+#endif
+    {
 		#region Internal variables
 
 		/// <summary>Trap enterprise Oid</summary>

--- a/Types/Counter32.cs
+++ b/Types/Counter32.cs
@@ -16,16 +16,21 @@
 using System;
 namespace SnmpSharpNet
 {
-	/// <summary>SMI Counter32 type implementation.</summary>
-	/// <remarks>
-	/// Counter32 value type is a 32-bit unsigned integer object that
-	/// is incremented by an agent until maximum unsigned integer value
-	/// is reached. When maximum value is reached, Counter32 value will
-	/// roll over to 0.
-	/// </remarks>
-	[Serializable]
-	public class Counter32:UInteger32, System.ICloneable
-	{		
+    /// <summary>SMI Counter32 type implementation.</summary>
+    /// <remarks>
+    /// Counter32 value type is a 32-bit unsigned integer object that
+    /// is incremented by an agent until maximum unsigned integer value
+    /// is reached. When maximum value is reached, Counter32 value will
+    /// roll over to 0.
+    /// </remarks>
+#if !NETCOREAPP11 && !NETSTANDARD15
+    [Serializable]
+#endif
+    public class Counter32: UInteger32
+#if !NETCOREAPP11 && !NETSTANDARD15
+        , ICloneable
+#endif
+    {		
 		/// <summary>Constructor</summary>
 		public Counter32():base()
 		{

--- a/Types/Counter64.cs
+++ b/Types/Counter64.cs
@@ -17,19 +17,26 @@ using System;
 using System.Globalization;
 namespace SnmpSharpNet
 {
-	/// <summary>ASN.1 Counter64 value implementation.</summary>
-	/// <remarks>
-	/// Counter64 value is unsigned 64-bit integer value that is incremented by the agent
-	/// until maximum value is reached. When maximum value is reached, Counter64 value will
-	/// roll over to 0.
-	/// </remarks>
-	[Serializable]
-	public class Counter64 : AsnType, IComparable<UInt64>, IComparable<Counter64>, ICloneable
-	{
-		/// <summary>
-		/// Internal 64-bit unsigned integer value.
-		/// </summary>
-		protected UInt64 _value;
+    /// <summary>ASN.1 Counter64 value implementation.</summary>
+    /// <remarks>
+    /// Counter64 value is unsigned 64-bit integer value that is incremented by the agent
+    /// until maximum value is reached. When maximum value is reached, Counter64 value will
+    /// roll over to 0.
+    /// </remarks>
+#if !NETSTANDARD15 && !NETCOREAPP11
+    [Serializable]
+#endif
+	public class Counter64 : AsnType, IComparable<UInt64>, IComparable<Counter64>
+#if !NETSTANDARD15 && !NETCOREAPP11
+,ICloneable
+#else
+        ,IEquatable<Counter64>, IEquatable<UInt64>
+#endif
+    {
+        /// <summary>
+        /// Internal 64-bit unsigned integer value.
+        /// </summary>
+        protected UInt64 _value;
 		
 		
 		/// <summary>
@@ -137,16 +144,15 @@ namespace SnmpSharpNet
 		{
 			return new Counter64(this);
 		}
-
-		/// <summary>
-		/// Return class value hash code
-		/// </summary>
-		/// <returns>Int32 hash of the class stored value</returns>
-		public override int GetHashCode()
+#if !NETCOREAPP11 && !NETSTANDARD15
+        /// <summary>
+        /// Return class value hash code
+        /// </summary>
+        /// <returns>Int32 hash of the class stored value</returns>
+        public override int GetHashCode()
 		{
 			return _value.GetHashCode();
 		}
-
 		/// <summary>
 		/// Compare class value against the object argument. Supported argument types are 
 		/// <see cref="Counter64"/> and UInt64.
@@ -172,18 +178,44 @@ namespace SnmpSharpNet
 		{
 			return Value.ToString(CultureInfo.CurrentCulture);
 		}
+#else
+        /// <summary>
+        /// Compare class value against the object argument. Supported argument types are 
+        /// <see cref="Counter64"/> and UInt64.
+        /// </summary>
+        /// <param name="obj">Object to compare values with</param>
+        /// <returns>True if object value is the same as this class, otherwise false.</returns>
+        public bool Equals(Counter64 obj)
+        {
+            if (obj == null)
+                return false;
+            if (obj is Counter64)
+                return _value.Equals(((Counter64)obj).Value);
+            return false;
+        }
+        /// <summary>
+        /// Compare class value against the object argument. Supported argument types are 
+        /// <see cref="Counter64"/> and UInt64.
+        /// </summary>
+        /// <param name="obj">Object to compare values with</param>
+        /// <returns>True if object value is the same as this class, otherwise false.</returns>
+        public bool Equals(UInt64 obj)
+        {
+            return _value.Equals((UInt64) obj);
+        }
+#endif
 
-		/// <summary>
-		/// Implicit casting of Counter64 value as UInt64 value
-		/// </summary>
-		/// <param name="value">Counter64 class whose value is cast as UInt64 value</param>
-		/// <returns>UInt64 value of the Counter64 class.</returns>
-		public static implicit operator UInt64(Counter64 value)
+        /// <summary>
+        /// Implicit casting of Counter64 value as UInt64 value
+        /// </summary>
+        /// <param name="value">Counter64 class whose value is cast as UInt64 value</param>
+        /// <returns>UInt64 value of the Counter64 class.</returns>
+        public static implicit operator UInt64(Counter64 value)
 		{
 			return value.Value;
 		}
 
-		#region Encode & Decode methods
+#region Encode & Decode methods
 
 		/// <summary>BER encode class value</summary>
 		/// <param name="buffer">MutableByte to append BER encoded value to.
@@ -246,7 +278,7 @@ namespace SnmpSharpNet
 			return offset;
 		}
 
-		#endregion
+#endregion
 
 
 		/// <summary>

--- a/Types/EndOfMibView.cs
+++ b/Types/EndOfMibView.cs
@@ -16,12 +16,17 @@
 using System;
 namespace SnmpSharpNet
 {
-	/// <summary>
-	/// Returned when end of MIB has been reached when performing GET-NEXT or GET-BULK operations.
-	/// </summary>
-	[Serializable]
-	public class EndOfMibView : V2Error, System.ICloneable
-	{
+    /// <summary>
+    /// Returned when end of MIB has been reached when performing GET-NEXT or GET-BULK operations.
+    /// </summary>
+#if !NETCOREAPP11 && !NETSTANDARD15
+    [Serializable]
+#endif
+    public class EndOfMibView : V2Error
+#if !NETCOREAPP11 && !NETSTANDARD15
+        , ICloneable
+#endif
+    {
 		/// <summary> The default class construtor.</summary>
 		public EndOfMibView():base()
 		{
@@ -72,13 +77,14 @@ namespace SnmpSharpNet
 		{
 			BuildHeader(buffer, Type, 0);
 		}
-		
-		/// <summary> Returns the string representation of the object.
-		/// </summary>
-		/// <returns>String prepresentation of the object.</returns>
-		public override String ToString()
+#if !NETCOREAPP11 && !NETSTANDARD15
+        /// <summary> Returns the string representation of the object.
+        /// </summary>
+        /// <returns>String prepresentation of the object.</returns>
+        public override String ToString()
 		{
 			return "SNMP End-of-MIB-View";
 		}
+#endif
 	}
 }

--- a/Types/EthernetAddress.cs
+++ b/Types/EthernetAddress.cs
@@ -17,14 +17,19 @@ using System;
 using System.Globalization;
 namespace SnmpSharpNet
 {
-	
-	/// <summary>EthernetAddress class encapsulates a 6 byte OctetString
-	/// representing an Ethernet MAC address.
-	/// </summary>
-	/// <remarks>THis class doesn't not represent a distinct ASN.1 data type. It is a helper
-	/// class to allow users to perform MAC address specific operations on OctetString values.</remarks>
+
+    /// <summary>EthernetAddress class encapsulates a 6 byte OctetString
+    /// representing an Ethernet MAC address.
+    /// </summary>
+    /// <remarks>THis class doesn't not represent a distinct ASN.1 data type. It is a helper
+    /// class to allow users to perform MAC address specific operations on OctetString values.</remarks>
+#if !NETCOREAPP11 && !NETSTANDARD15
 	[Serializable]
-	public class EthernetAddress : OctetString, ICloneable
+#endif
+	public class EthernetAddress : OctetString
+#if !NETCOREAPP11 && !NETSTANDARD15
+        , ICloneable
+#endif
 	{
 		/// <summary>Constructor. Initialize the class to 0000.0000.0000
 		/// </summary>
@@ -93,7 +98,7 @@ namespace SnmpSharpNet
 		{
 			if( value == null || value.Length <= 0 )
 				throw new ArgumentException("Invalid argument. String is empty.");
-			string workString = (string)value.Clone();
+		    string workString = new string(value.ToCharArray());
 			for (int cnt = 0; cnt < value.Length; cnt++)
 			{
 				if (!Char.IsNumber(workString[cnt]) && Char.ToUpper(workString[cnt]) != 'A' &&
@@ -119,7 +124,7 @@ namespace SnmpSharpNet
 				pos += 2;
 			}
 		}
-		
+#if !NETCOREAPP11 && !NETSTANDARD15
 		/// <summary>
 		/// Return Ethernet MAC address as a string formatted as: xxxx.xxxx.xxxx
 		/// </summary>
@@ -128,5 +133,6 @@ namespace SnmpSharpNet
 		{
 			return String.Format(CultureInfo.CurrentCulture,"{0:x2}{1:x2}.{2:x2}{3:x2}.{4:x2}{5:x2}", _data[0], _data[1], _data[2], _data[3], _data[4], _data[5]);
 		}
+#endif
 	}
 }

--- a/Types/Gauge32.cs
+++ b/Types/Gauge32.cs
@@ -16,11 +16,16 @@
 using System;
 namespace SnmpSharpNet
 {
-	/// <summary>ASN.1 Gauge32 value class.
-	/// </summary>
-	[Serializable]
-	public class Gauge32:UInteger32, ICloneable
-	{
+    /// <summary>ASN.1 Gauge32 value class.
+    /// </summary>
+#if !NETCOREAPP11 && !NETSTANDARD15
+    [Serializable]
+#endif
+    public class Gauge32: UInteger32
+#if !NETCOREAPP11 && !NETSTANDARD15
+        , ICloneable
+#endif
+    {
 		/// <summary> Constructs the default counter object.
 		/// The initial value is defined
 		/// by the super class default constructor

--- a/Types/Integer32.cs
+++ b/Types/Integer32.cs
@@ -16,16 +16,23 @@
 using System;
 namespace SnmpSharpNet
 {
-	/// <summary>ASN.1 Integer32 class.</summary>
-	/// <remarks>
-	/// This class defines the SNMP 32-bit signed integer
-	/// used by the SNMP SMI. This class also serves as a 
-	/// base class for any additional SNMP SMI types that 
-	/// exits now or may be defined in the future.
-	/// </remarks>
+    /// <summary>ASN.1 Integer32 class.</summary>
+    /// <remarks>
+    /// This class defines the SNMP 32-bit signed integer
+    /// used by the SNMP SMI. This class also serves as a 
+    /// base class for any additional SNMP SMI types that 
+    /// exits now or may be defined in the future.
+    /// </remarks>
+#if !NETCOREAPP11 && !NETSTANDARD15
 	[Serializable]
-	public class Integer32 : AsnType, IComparable<Integer32>, IComparable<Int32>, ICloneable
-	{
+#endif
+	public class Integer32 : AsnType, IComparable<Integer32>, IComparable<Int32>
+#if !NETCOREAPP11 && !NETSTANDARD15
+, ICloneable
+#else
+        ,IEquatable<Integer32>,IEquatable<int>
+#endif
+    {
 		/// <summary>Internal class value</summary>
 		protected int _value;
 		
@@ -118,27 +125,14 @@ namespace SnmpSharpNet
 		{
 			return new Integer32(this);
 		}
-		
+#if !NETCOREAPP11 && !NETSTANDARD15
 		/// <summary> Returns the string representation of the object.</summary>
 		/// <returns>String representation of the class value.</returns>
 		public override System.String ToString()
 		{
 			return _value.ToString();
 		}
-
-		/// <summary>
-		/// Implicit casting of Integer32 value as Int32 value
-		/// </summary>
-		/// <param name="value">Integer32 class whose value is cast as Int32 value</param>
-		/// <returns>Int32 value of the Integer32 class.</returns>
-		public static implicit operator Int32(Integer32 value)
-		{
-			if (value == null)
-				return 0;
-			return value.Value;
-		}
-
-		/// <summary>
+        /// <summary>
 		/// Return class value hash code
 		/// </summary>
 		/// <returns>Int32 hash of the class stored value</returns>
@@ -146,6 +140,66 @@ namespace SnmpSharpNet
 		{
 			return _value.GetHashCode();
 		}
+        /// <summary>
+		/// Compare class value against the object argument. Supported argument types are 
+		/// <see cref="Integer32"/> and Int32.
+		/// </summary>
+		/// <param name="obj">Object to compare values with</param>
+		/// <returns>True if object value is the same as this class, otherwise false.</returns>
+		public override bool Equals(object obj)
+		{
+			if (obj is Integer32)
+			{
+				Integer32 i32 = (Integer32)obj;
+				return _value.Equals(i32.Value);
+			}
+			else if (obj is Int32)
+			{
+				Int32 i32 = (Int32)obj;
+				return _value.Equals(i32);
+			}
+			return false; // last resort
+		}
+#else
+        /// <summary>
+        /// Compare class value against the object argument. Supported argument types are 
+        /// <see cref="Integer32"/> and Int32.
+        /// </summary>
+        /// <param name="obj">Object to compare values with</param>
+        /// <returns>True if object value is the same as this class, otherwise false.</returns>
+        public bool Equals(Integer32 obj)
+        {
+            if (obj is Integer32)
+            {
+                Integer32 i32 = (Integer32)obj;
+                return _value.Equals(i32.Value);
+            }
+            return false; // last resort
+        }
+        /// <summary>
+        /// Compare class value against the object argument. Supported argument types are 
+        /// <see cref="Integer32"/> and Int32.
+        /// </summary>
+        /// <param name="obj">Object to compare values with</param>
+        /// <returns>True if object value is the same as this class, otherwise false.</returns>
+        public bool Equals(int obj)
+        {
+            return _value.Equals(obj);
+        }
+#endif
+        /// <summary>
+        /// Implicit casting of Integer32 value as Int32 value
+        /// </summary>
+        /// <param name="value">Integer32 class whose value is cast as Int32 value</param>
+        /// <returns>Int32 value of the Integer32 class.</returns>
+        public static implicit operator Int32(Integer32 value)
+		{
+			if (value == null)
+				return 0;
+			return value.Value;
+		}
+
+
 
 		/// <summary>
 		/// Set class value to a random integer.
@@ -156,7 +210,7 @@ namespace SnmpSharpNet
 			_value = rand.Next();
 		}
 
-		#region encode and decode methods
+#region encode and decode methods
 
 		/// <summary> Used to encode the integer value into an ASN.1 buffer.
 		/// The passed encoder defines the method for encoding the
@@ -275,7 +329,7 @@ namespace SnmpSharpNet
 			return offset;
 		}
 
-		#endregion encode and decode methods
+#endregion encode and decode methods
 
 		/// <summary>
 		/// Compare implementation that will compare this class value with the value of another <see cref="Integer32"/> class.
@@ -301,26 +355,7 @@ namespace SnmpSharpNet
 			return _value.CompareTo(other);
 		}
 
-		/// <summary>
-		/// Compare class value against the object argument. Supported argument types are 
-		/// <see cref="Integer32"/> and Int32.
-		/// </summary>
-		/// <param name="obj">Object to compare values with</param>
-		/// <returns>True if object value is the same as this class, otherwise false.</returns>
-		public override bool Equals(object obj)
-		{
-			if (obj is Integer32)
-			{
-				Integer32 i32 = (Integer32)obj;
-				return _value.Equals(i32.Value);
-			}
-			else if (obj is Int32)
-			{
-				Int32 i32 = (Int32)obj;
-				return _value.Equals(i32);
-			}
-			return false; // last resort
-		}
+
 
 		/// <summary>
 		/// Comparison operator

--- a/Types/NoSuchInstance.cs
+++ b/Types/NoSuchInstance.cs
@@ -16,17 +16,22 @@
 using System;
 namespace SnmpSharpNet
 {
-	
-	
-	/// <summary>SNMPv2 noSuchInstance error</summary>
-	/// <remarks>
-	/// Returned when requested instance is not present in a table of the SNMP version 2 agent.
-	/// 
-	/// This type is returned as value to a requested Oid. When looping through results, check Vb.Value
-	/// member for V2Error returns.
-	/// </remarks>
-	[Serializable]
-	public class NoSuchInstance : V2Error, ICloneable
+
+
+    /// <summary>SNMPv2 noSuchInstance error</summary>
+    /// <remarks>
+    /// Returned when requested instance is not present in a table of the SNMP version 2 agent.
+    /// 
+    /// This type is returned as value to a requested Oid. When looping through results, check Vb.Value
+    /// member for V2Error returns.
+    /// </remarks>
+#if !NETCOREAPP11 && !NETSTANDARD15
+    [Serializable]
+#endif
+    public class NoSuchInstance : V2Error
+#if !NETCOREAPP11 && !NETSTANDARD15
+        , ICloneable
+#endif
 	{
 		/// <summary>Constructor.</summary>
 		public NoSuchInstance():base()
@@ -76,11 +81,13 @@ namespace SnmpSharpNet
 			BuildHeader(buffer, Type, 0);
 		}
 
+#if !NETCOREAPP11 && !NETSTANDARD15
 		/// <summary> Returns the string representation of the object.</summary>
 		/// <returns>String representatio of the class</returns>
 		public override System.String ToString()
 		{
 			return "SNMP No-Such-Instance";
 		}
+#endif
 	}
 }

--- a/Types/NoSuchObject.cs
+++ b/Types/NoSuchObject.cs
@@ -16,27 +16,32 @@
 using System;
 namespace SnmpSharpNet
 {
-	
-	
-	/// <summary>SNMPv2 NoSuchObject error</summary>
-	/// <remarks>
-	/// NoSuchObject is returned by the agent in response to a SNMP version 2 request 
-	/// when requested object does not exist in its MIB.
-	/// This value is returned as a <seealso cref="Vb.Value"/> with data of length 0
-	/// 
-	/// For example:
-	/// <code lang="cs">
-	/// // [... prepare for a get operation ...]
-	/// Pdu response = target.Request(outpdu, params);
-	/// foreach(Vb vb in response.VbList) {
-	///		if( vb.Value is NoSuchObject ) {
-	///			return "Requested MIB variable does not exist on the agent.";
-	///		}
-	///	}
-	/// </code>
-	/// </remarks>
+
+
+    /// <summary>SNMPv2 NoSuchObject error</summary>
+    /// <remarks>
+    /// NoSuchObject is returned by the agent in response to a SNMP version 2 request 
+    /// when requested object does not exist in its MIB.
+    /// This value is returned as a <seealso cref="Vb.Value"/> with data of length 0
+    /// 
+    /// For example:
+    /// <code lang="cs">
+    /// // [... prepare for a get operation ...]
+    /// Pdu response = target.Request(outpdu, params);
+    /// foreach(Vb vb in response.VbList) {
+    ///		if( vb.Value is NoSuchObject ) {
+    ///			return "Requested MIB variable does not exist on the agent.";
+    ///		}
+    ///	}
+    /// </code>
+    /// </remarks>
+#if !NETCOREAPP11 && !NETSTANDARD15
 	[Serializable]
-	public class NoSuchObject:V2Error, ICloneable
+#endif
+    public class NoSuchObject:V2Error
+#if !NETCOREAPP11 && !NETSTANDARD15
+        , ICloneable
+#endif
 	{		
 		
 		/// <summary>Constructor.</summary>
@@ -89,12 +94,14 @@ namespace SnmpSharpNet
 		{
 			BuildHeader(buffer, Type, 0);
 		}
-		
+#if !NETCOREAPP11 && !NETSTANDARD15
+
 		/// <summary> Returns the string representation of the object.</summary>
 		/// <returns>String representation of the class</returns>
 		public override System.String ToString()
 		{
 			return "SNMP No-Such-Object";
 		}
+#endif
 	}
 }

--- a/Types/Null.cs
+++ b/Types/Null.cs
@@ -16,10 +16,15 @@
 using System;
 namespace SnmpSharpNet
 {
-	
-	/// <summary>ASN.1 Null value implementation.</summary>
+
+    /// <summary>ASN.1 Null value implementation.</summary>
+#if !NETCOREAPP11 && !NETSTANDARD15
 	[Serializable]
-	public class Null : AsnType, ICloneable
+#endif
+    public class Null : AsnType
+#if !NETCOREAPP11 && !NETSTANDARD15
+        , ICloneable
+#endif
 	{
 		/// <summary>Constructor</summary>
 		public Null()
@@ -33,7 +38,7 @@ namespace SnmpSharpNet
 		{
 		}
 		
-		#region Encode & decode methods
+#region Encode & decode methods
 
 		/// <summary> 
 		/// ASN.1 encode Null value
@@ -70,7 +75,7 @@ namespace SnmpSharpNet
 			return offset;
 		}
 		
-		#endregion Encode & decode methods
+#endregion Encode & decode methods
 		
 		/// <summary>Clone current object</summary>
 		/// <returns>Duplicate of the current object.</returns>
@@ -78,12 +83,14 @@ namespace SnmpSharpNet
 		{
 			return new Null(this);
 		}
-		
+#if !NETCOREAPP11 && !NETSTANDARD15
+
 		/// <summary> Returns a string representation of the SNMP NULL object</summary>
 		/// <returns>String representation of the class</returns>
 		public override System.String ToString()
 		{
 			return "Null";
 		}
+#endif
 	}
 }

--- a/Types/OctetString.cs
+++ b/Types/OctetString.cs
@@ -20,11 +20,18 @@ using System.Collections.Generic;
 
 namespace SnmpSharpNet
 {
-	
-	/// <summary>ASN.1 OctetString type implementation</summary>
+
+    /// <summary>ASN.1 OctetString type implementation</summary>
+#if !NETCOREAPP11 && !NETSTANDARD15
 	[Serializable]
-	public class OctetString : AsnType, ICloneable, IComparable<byte[]>, IComparable<OctetString>, IEnumerable<byte>
-	{
+#endif
+    public class OctetString : AsnType, IComparable<byte[]>, IComparable<OctetString>, IEnumerable<byte>
+#if !NETCOREAPP11 && !NETSTANDARD15
+, ICloneable
+#else
+        ,IEquatable<OctetString>, IEquatable<string>
+#endif
+    {
 		/// <summary>Data buffer</summary>
 		protected byte[] _data;
 		
@@ -317,6 +324,9 @@ namespace SnmpSharpNet
 			}
 			return "";
 		}
+
+#if !NETCOREAPP11 && !NETSTANDARD15
+
 		/// <summary>Return string representation of the OctetStrig object. If non-printable characters have been
 		/// found in the object, output is a hex representation of the string.
 		/// </summary>
@@ -340,27 +350,7 @@ namespace SnmpSharpNet
 			}
 			return rs;
 		}
-
-		/// <summary>
-		/// Return string formatted hexadecimal representation of the objects value.
-		/// </summary>
-		/// <returns>String representation of hexadecimal formatted class value.</returns>
-		public string ToHexString()
-		{
-			StringBuilder b = new StringBuilder();
-			for (int i = 0; i < _data.Length; ++i)
-			{
-				int x = (int)_data[i] & 0xff;
-				if (x < 16)
-					b.Append('0');
-				b.Append(System.Convert.ToString(x, 16).ToUpper());
-
-				if (i < _data.Length - 1)
-					b.Append(' ');
-			}
-			return b.ToString();
-		}
-		/// <summary>
+        /// <summary>
 		/// Compare against another object. Acceptable object types are <see cref="OctetString"/> and
 		/// <see cref="System.String"/>.
 		/// </summary>
@@ -402,6 +392,94 @@ namespace SnmpSharpNet
 		{
 			return base.GetHashCode();
 		}
+#else
+        /// <summary>
+        /// Compare against another object. Acceptable object types are <see cref="OctetString"/> and
+        /// <see cref="System.String"/>.
+        /// </summary>
+        /// <param name="obj">Object of type <see cref="OctetString"/> or <see cref="System.String"/> to compare against</param>
+        /// <returns>true if object content is the same, false if different or if incompatible object type</returns>
+        public bool Equals(OctetString obj)
+        {
+            byte[] d = null;
+
+            OctetString o = obj as OctetString;
+            d = o.GetData();
+
+            // check for null value in comparison
+            if (d == null || _data == null)
+            {
+                if (d == null && _data == null)
+                    return true; // both values are null
+                return false; // one value is not null
+            }
+            if (d.Length != _data.Length)
+            {
+                return false; // Objects have different length
+            }
+            for (int cnt = 0; cnt < d.Length; cnt++)
+            {
+                if (d[cnt] != _data[cnt])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Compare against another object. Acceptable object types are <see cref="OctetString"/> and
+        /// <see cref="System.String"/>.
+        /// </summary>
+        /// <param name="obj">Object of type <see cref="OctetString"/> or <see cref="System.String"/> to compare against</param>
+        /// <returns>true if object content is the same, false if different or if incompatible object type</returns>
+        public bool Equals(string obj)
+        {
+            byte[] d = null;
+
+            d = System.Text.UTF8Encoding.UTF8.GetBytes((String) obj);
+
+            // check for null value in comparison
+            if (d == null || _data == null)
+            {
+                if (d == null && _data == null)
+                    return true; // both values are null
+                return false; // one value is not null
+            }
+            if (d.Length != _data.Length)
+            {
+                return false; // Objects have different length
+            }
+            for (int cnt = 0; cnt < d.Length; cnt++)
+            {
+                if (d[cnt] != _data[cnt])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+#endif
+        /// <summary>
+        /// Return string formatted hexadecimal representation of the objects value.
+        /// </summary>
+        /// <returns>String representation of hexadecimal formatted class value.</returns>
+        public string ToHexString()
+		{
+			StringBuilder b = new StringBuilder();
+			for (int i = 0; i < _data.Length; ++i)
+			{
+				int x = (int)_data[i] & 0xff;
+				if (x < 16)
+					b.Append('0');
+				b.Append(System.Convert.ToString(x, 16).ToUpper());
+
+				if (i < _data.Length - 1)
+					b.Append(' ');
+			}
+			return b.ToString();
+		}
+		
 		/// <summary>
 		/// Overloading equality operator
 		/// </summary>
@@ -485,7 +563,7 @@ namespace SnmpSharpNet
 			_data = null;
 		}
 
-		#region Encode and decode methods
+#region Encode and decode methods
 
 		/// <summary>BER encode OctetString variable.</summary>
 		/// <param name="buffer"><see cref="MutableByte"/> encoding destination.</param>
@@ -536,7 +614,7 @@ namespace SnmpSharpNet
 			return offset;
 		}
 
-		#endregion Encode and decode methods
+#endregion Encode and decode methods
 
 		/// <summary>
 		/// Returns an enumerator that iterates through the OctetString byte collection

--- a/Types/Opaque.cs
+++ b/Types/Opaque.cs
@@ -19,13 +19,18 @@ namespace SnmpSharpNet
 {
 
 
-	/// <summary>Opaque type is an application-wide type supports the capability to pass arbitrary
-	/// ASN.1 syntax</summary>
-	/// <remarks>SMIv2 defines Opaque type as provided solely for backward-compatibility, and
-	/// shall not be used for newly-defined object types</remarks>
-	[Serializable]
-	public class Opaque : OctetString, System.ICloneable
-	{
+    /// <summary>Opaque type is an application-wide type supports the capability to pass arbitrary
+    /// ASN.1 syntax</summary>
+    /// <remarks>SMIv2 defines Opaque type as provided solely for backward-compatibility, and
+    /// shall not be used for newly-defined object types</remarks>
+#if !NETCOREAPP11 && !NETSTANDARD15
+    [Serializable]
+#endif
+    public class Opaque : OctetString
+#if !NETCOREAPP11 && !NETSTANDARD15
+        , ICloneable
+#endif
+    {
 		/// <summary>Constructor</summary>
 		public Opaque():base()
 		{

--- a/Types/Sequence.cs
+++ b/Types/Sequence.cs
@@ -4,12 +4,17 @@ using System.Text;
 
 namespace SnmpSharpNet
 {
-	/// <summary>
-	/// Represents SNMP sequence
-	/// </summary>
-	[Serializable]
-	public class Sequence : AsnType, ICloneable
-	{
+    /// <summary>
+    /// Represents SNMP sequence
+    /// </summary>
+#if !NETCOREAPP11 && !NETSTANDARD15
+    [Serializable]
+#endif
+    public class Sequence : AsnType
+#if !NETCOREAPP11 && !NETSTANDARD15
+        , ICloneable
+#endif
+    {
 		/// <summary>
 		/// data buffer
 		/// </summary>

--- a/Types/TimeTicks.cs
+++ b/Types/TimeTicks.cs
@@ -16,15 +16,20 @@
 using System;
 namespace SnmpSharpNet
 {
-	
-	
-	/// <summary>SMI TimeTicks class</summary>
-	/// <remarks>
-	/// TimeTicks value is stored as an unsigned
-	/// 32-bit integer representing device uptime in 1/100s of a second time periods.
-	/// </remarks>
+
+
+    /// <summary>SMI TimeTicks class</summary>
+    /// <remarks>
+    /// TimeTicks value is stored as an unsigned
+    /// 32-bit integer representing device uptime in 1/100s of a second time periods.
+    /// </remarks>
+#if !NETCOREAPP11 && !NETSTANDARD15
 	[Serializable]
-	public class TimeTicks:UInteger32,ICloneable
+#endif
+	public class TimeTicks:UInteger32
+#if !NETCOREAPP11 && !NETSTANDARD15
+        ,ICloneable
+#endif
 	{
 		/// <summary>Constructor</summary>
 		public TimeTicks():base()
@@ -98,7 +103,8 @@ namespace SnmpSharpNet
 				return res;
 			}
 		}
-
+#if !NETCOREAPP11 && !NETSTANDARD15
+        
 		/// <summary>
 		/// Returns the string representation of the object.
 		/// </summary>
@@ -152,5 +158,6 @@ namespace SnmpSharpNet
 		{
 			return _value.GetHashCode();
 		}
+#endif
 	}
 }

--- a/Types/UInteger32.cs
+++ b/Types/UInteger32.cs
@@ -17,11 +17,16 @@ using System;
 using System.Globalization;
 namespace SnmpSharpNet
 {
-	
-	/// <summary>SMI unsigned 32-bit integer value class.
-	/// </summary>
+
+    /// <summary>SMI unsigned 32-bit integer value class.
+    /// </summary>
+#if !NETCOREAPP11 && !NETSTANDARD15
 	[Serializable]
-	public class UInteger32 : AsnType, IComparable<UInteger32>, IComparable<UInt32>
+#endif
+    public class UInteger32 : AsnType, IComparable<UInteger32>, IComparable<UInt32>
+#if NETCOREAPP11 || NETSTANDARD15
+        ,IEquatable<UInteger32>,IEquatable<uint>
+#endif
 	{
 		/// <summary>Internal unsigned integer 32-bit value
 		/// </summary>
@@ -106,14 +111,7 @@ namespace SnmpSharpNet
 			}
 		}
 
-		/// <summary> 
-		/// Returns the string representation of the object.
-		/// </summary>
-		/// <returns>String representation of the of the class value.</returns>
-		public override System.String ToString()
-		{
-			return System.Convert.ToString(_value, CultureInfo.CurrentCulture);
-		}
+
 
 		/// <summary>
 		/// Returns a duplicate of the current object
@@ -138,7 +136,7 @@ namespace SnmpSharpNet
 			return value.Value;
 		}
 
-		#region Encode and decode methods
+#region Encode and decode methods
 
 		/// <summary>BER encode class value.</summary>
 		/// <param name="buffer">Target buffer. Value is appended to the end of it.</param>
@@ -205,7 +203,7 @@ namespace SnmpSharpNet
 			return offset;
 		}
 		
-		#endregion Encode and decode methods
+#endregion Encode and decode methods
 
 		/// <summary>
 		/// Compare implementation that will compare this class value with the value of another <see cref="UInteger32"/> class.
@@ -226,6 +224,7 @@ namespace SnmpSharpNet
 		{
 			return _value.CompareTo(other);
 		}
+#if !NETCOREAPP11 && !NETSTANDARD15
 
 		/// <summary>
 		/// Compare class value against the object argument. Supported argument types are 
@@ -249,14 +248,62 @@ namespace SnmpSharpNet
 			}
 			return false; // last resort
 		}
-
-		/// <summary>
-		/// Comparison operator
+        		/// <summary> 
+		/// Returns the string representation of the object.
 		/// </summary>
-		/// <param name="first">First <see cref="UInteger32"/> class value to compare</param>
-		/// <param name="second">Second <see cref="UInteger32"/> class value to compare</param>
-		/// <returns>True if class values match, otherwise false</returns>
-		public static bool operator ==(UInteger32 first, UInteger32 second)
+		/// <returns>String representation of the of the class value.</returns>
+		public override System.String ToString()
+		{
+			return System.Convert.ToString(_value, CultureInfo.CurrentCulture);
+		}
+
+        		/// <summary>
+		/// Returns hashed class value.
+		/// </summary>
+		/// <returns>Int32 hash value</returns>
+		public override int GetHashCode()
+		{
+			return _value.GetHashCode();
+		}
+#else
+        /// <summary>
+        /// Compare class value against the object argument. Supported argument types are 
+        /// <see cref="UInteger32"/> and Int32.
+        /// </summary>
+        /// <param name="obj">Object to compare values with</param>
+        /// <returns>True if object value is the same as this class, otherwise false.</returns>
+        public bool Equals(UInteger32 obj)
+        {
+            if (obj == null)
+                return false;
+           
+                UInteger32 u32 = (UInteger32)obj;
+                return _value.Equals(u32.Value);
+            
+        }
+
+	    /// <summary>
+	    /// Compare class value against the object argument. Supported argument types are 
+	    /// <see cref="UInteger32"/> and Int32.
+	    /// </summary>
+	    /// <param name="obj">Object to compare values with</param>
+	    /// <returns>True if object value is the same as this class, otherwise false.</returns>
+	    public bool Equals(uint obj)
+	    {
+	        if (obj == null)
+	            return false;
+
+	        UInt32 u32 = (UInt32) obj;
+	        return _value.Equals(u32);
+	    }
+#endif
+        /// <summary>
+        /// Comparison operator
+        /// </summary>
+        /// <param name="first">First <see cref="UInteger32"/> class value to compare</param>
+        /// <param name="second">Second <see cref="UInteger32"/> class value to compare</param>
+        /// <returns>True if class values match, otherwise false</returns>
+        public static bool operator ==(UInteger32 first, UInteger32 second)
 		{
 			if ((object)first == null && (object)second == null)
 				return true;
@@ -315,14 +362,7 @@ namespace SnmpSharpNet
 			return false;
 		}
 
-		/// <summary>
-		/// Returns hashed class value.
-		/// </summary>
-		/// <returns>Int32 hash value</returns>
-		public override int GetHashCode()
-		{
-			return _value.GetHashCode();
-		}
+
 		/// <summary>
 		/// Addition operator.
 		/// </summary>

--- a/Types/V2Error.cs
+++ b/Types/V2Error.cs
@@ -21,8 +21,11 @@ namespace SnmpSharpNet
 	/// <remarks>
 	/// For details see <see cref="NoSuchInstance"/>, <see cref="NoSuchObject"/> and <see cref="EndOfMibView"/>.
 	/// </remarks>
-	public class V2Error : AsnType, ICloneable
-	{		
+	public class V2Error : AsnType
+#if !NETCOREAPP11 && !NETSTANDARD15
+        , ICloneable
+#endif
+    {		
 		/// <summary>
 		/// Constructor
 		/// </summary>

--- a/Types/V2PartyClock.cs
+++ b/Types/V2PartyClock.cs
@@ -22,7 +22,10 @@ namespace SnmpSharpNet
 	/// The Party Clock is currently
 	/// Obsolete, but included for backwards compatibility. Obsoleted in RFC 1902.
 	/// </remarks>
-	public class V2PartyClock:UInteger32,ICloneable
+	public class V2PartyClock:UInteger32
+#if !NETCOREAPP11 && !NETSTANDARD15
+,ICloneable
+#endif
 	{
 		/// <summary>Constructor</summary>
 		public V2PartyClock():base()
@@ -50,7 +53,8 @@ namespace SnmpSharpNet
 		{
 			return new V2PartyClock(this);
 		}
-		
+#if !NETCOREAPP11 && !NETSTANDARD15
+
 		/// <summary>Returns the string representation of the object.</summary>
 		/// <returns>String representation of the class value.</returns>
 		public override System.String ToString()
@@ -94,5 +98,6 @@ namespace SnmpSharpNet
 			
 			return buf.ToString();
 		}
+#endif
 	}
 }

--- a/Vb.cs
+++ b/Vb.cs
@@ -22,7 +22,10 @@ namespace SnmpSharpNet {
 	/// <summary>
 	/// Vb item. Stores Oid => value pair for each value
 	/// </summary>
-	public class Vb : AsnType, ICloneable
+	public class Vb : AsnType
+#if !NETCOREAPP11 && !NETSTANDARD15
+, ICloneable
+#endif
 	{
 		/// <summary>
 		/// OID of the object
@@ -123,6 +126,8 @@ namespace SnmpSharpNet {
 		public override Object Clone() {
 			return new Vb(this._oid, this._value);
 		}
+#if !NETCOREAPP11 && !NETSTANDARD15
+
 		/// <summary>
 		/// Return printable string in the format oid: value
 		/// </summary>
@@ -130,6 +135,7 @@ namespace SnmpSharpNet {
 		public override string ToString() {
 			return _oid.ToString() + ": (" + SnmpConstants.GetTypeName(_value.Type) + ") " + _value.ToString();
 		}
+#endif
 		/// <summary>BER encode the variable binding
 		/// </summary>
 		/// <param name="buffer"><see cref="MutableByte"/> class to the end of which encoded variable

--- a/security/AuthenticationMD5.cs
+++ b/security/AuthenticationMD5.cs
@@ -120,9 +120,13 @@ namespace SnmpSharpNet
 
 			int password_index = 0;
 			int count = 0;
-			MD5 md5 = new MD5CryptoServiceProvider();
+#if !NETCOREAPP11 && !NETSTANDARD15
+            MD5 md5 = new MD5CryptoServiceProvider();
+#else
+            MD5 md5 = MD5.Create();
+#endif
 
-			byte[] sourceBuffer = new byte[1048576];
+            byte[] sourceBuffer = new byte[1048576];
 			byte[] buf = new byte[64];
 			while (count < 1048576)
 			{
@@ -169,10 +173,18 @@ namespace SnmpSharpNet
 		/// <returns>Hash value</returns>
 		public byte[] ComputeHash(byte[] data, int offset, int count)
 		{
-			MD5 md5 = new MD5CryptoServiceProvider();
-			byte[] res = md5.ComputeHash(data, offset, count);
-			md5.Clear();
-			return res;
+#if !NETCOREAPP11 && !NETSTANDARD15
+            MD5 md5 = new MD5CryptoServiceProvider();
+#else
+            MD5 md5 = MD5.Create();
+#endif
+            byte[] res = md5.ComputeHash(data, offset, count);
+#if !NETCOREAPP11 && !NETSTANDARD15
+			md5.Clear(); // release resources
+#else
+            md5.Dispose();
+#endif
+            return res;
 		}
 	}
 }

--- a/security/AuthenticationSHA1.cs
+++ b/security/AuthenticationSHA1.cs
@@ -49,8 +49,12 @@ namespace SnmpSharpNet
 			{
 				result[i] = hash[i];
 			}
+#if !NETCOREAPP11 && !NETSTANDARD15
 			sha.Clear(); // release resources
-			return result;
+#else
+            sha.Dispose();
+#endif
+            return result;
 		}
 		/// <summary>
 		/// Authenticate packet and return authentication parameters value to the caller
@@ -69,8 +73,12 @@ namespace SnmpSharpNet
 			{
 				result[i] = hash[i];
 			}
+#if !NETCOREAPP11 && !NETSTANDARD15
 			sha.Clear(); // release resources
-			return result;
+#else
+            sha.Dispose();
+#endif
+            return result;
 		}
 		/// <summary>
 		/// Verifies correct SHA-1 authentication of the frame. Prior to calling this method, you have to extract authentication
@@ -88,8 +96,12 @@ namespace SnmpSharpNet
 			HMACSHA1 sha = new HMACSHA1(authKey);
 			byte[] hash = sha.ComputeHash(wholeMessage);
 			MutableByte myhash = new MutableByte(hash, 12);
+#if !NETCOREAPP11 && !NETSTANDARD15
 			sha.Clear(); // release resources
-			if (myhash.Equals(authenticationParameters))
+#else
+            sha.Dispose();
+#endif
+            if (myhash.Equals(authenticationParameters))
 			{
 				return true;
 			}
@@ -107,8 +119,12 @@ namespace SnmpSharpNet
 			HMACSHA1 sha = new HMACSHA1(authKey);
 			byte[] hash = sha.ComputeHash(wholeMessage);
 			MutableByte myhash = new MutableByte(hash, 12);
+#if !NETCOREAPP11 && !NETSTANDARD15
 			sha.Clear(); // release resources
-			if (myhash.Equals(authenticationParameters))
+#else
+            sha.Dispose();
+#endif
+            if (myhash.Equals(authenticationParameters))
 			{
 				return true;
 			}
@@ -129,10 +145,14 @@ namespace SnmpSharpNet
 
 			int password_index = 0;
 			int count = 0;
-			SHA1 sha = new SHA1CryptoServiceProvider();
+#if !NETCOREAPP11 && !NETSTANDARD15
+            SHA1 sha = new SHA1CryptoServiceProvider();
+#else
+            SHA1 sha = SHA1.Create();
+#endif
 
-			/* Use while loop until we've done 1 Megabyte */
-			byte[] sourceBuffer = new byte[1048576];
+            /* Use while loop until we've done 1 Megabyte */
+            byte[] sourceBuffer = new byte[1048576];
 			byte[] buf = new byte[64];
 			while (count < 1048576)
 			{
@@ -153,8 +173,12 @@ namespace SnmpSharpNet
 			tmpbuf.Append(engineID);
 			tmpbuf.Append(digest);
 			byte[] res = sha.ComputeHash(tmpbuf);
-			sha.Clear(); // release resources
-			return res;
+#if !NETCOREAPP11 && !NETSTANDARD15
+            sha.Clear();
+#else
+            sha.Dispose();
+#endif
+            return res;
 		}
 
 		/// <summary>
@@ -181,10 +205,18 @@ namespace SnmpSharpNet
 		/// <returns>Hash value</returns>
 		public byte[] ComputeHash(byte[] data, int offset, int count)
 		{
-			SHA1 sha = new SHA1CryptoServiceProvider();
+#if !NETCOREAPP11 && !NETSTANDARD15
+            SHA1 sha = new SHA1CryptoServiceProvider();
+#else
+            SHA1 sha = SHA1.Create();
+#endif
 			byte[] res = sha.ComputeHash(data, offset, count);
-			sha.Clear();
-			return res;
+#if !NETCOREAPP11 && !NETSTANDARD15
+            sha.Clear();
+#else
+            sha.Dispose();
+#endif
+            return res;
 		}
 	}
 }

--- a/security/MsgFlags.cs
+++ b/security/MsgFlags.cs
@@ -28,8 +28,11 @@ namespace SnmpSharpNet
 	/// Message flags field is a 1 byte <see cref="OctetString"/> encoded
 	/// field.
 	/// </remarks>
-	public class MsgFlags : AsnType, ICloneable
-	{
+	public class MsgFlags : AsnType
+#if !NETCOREAPP11 && !NETSTANDARD15
+, ICloneable
+#endif
+    {
 		/// <summary>
 		/// Bit value that, when set, indicates that packet has been authenticated.
 		/// </summary>
@@ -159,6 +162,7 @@ namespace SnmpSharpNet
 		{
 			return new MsgFlags(_authenticationFlag, _privacyFlag, _reportableFlag);
 		}
+#if !NETCOREAPP11 && !NETSTANDARD15
 
 		/// <summary>
 		/// Return string representation of the object.
@@ -169,5 +173,6 @@ namespace SnmpSharpNet
 			return string.Format("Reportable {0} Authenticated {1} Privacy {2}", _reportableFlag.ToString(),
 				_authenticationFlag.ToString(), _privacyFlag.ToString());
 		}
+#endif
 	}
 }

--- a/security/Privacy3DES.cs
+++ b/security/Privacy3DES.cs
@@ -91,8 +91,12 @@ namespace SnmpSharpNet
 			byte[] encryptedData = null;
 			try
 			{
+#if !NETCOREAPP11 && !NETSTANDARD15
 				TripleDES tdes = new TripleDESCryptoServiceProvider();
-				tdes.Mode = CipherMode.CBC;
+#else
+                TripleDES tdes = TripleDES.Create();
+#endif
+                tdes.Mode = CipherMode.CBC;
 				tdes.Padding = PaddingMode.None;
 				// normalize key - generated key is 32 bytes long, we need 24 bytes to encrypt
 				byte[] normKey = new byte[24];
@@ -147,8 +151,12 @@ namespace SnmpSharpNet
 			byte[] decryptedData = null;
 			try
 			{
+#if !NETCOREAPP11 && !NETSTANDARD15
 				TripleDES tdes = new TripleDESCryptoServiceProvider();
-				tdes.Mode = CipherMode.CBC;
+#else
+                TripleDES tdes = TripleDES.Create();
+#endif
+                tdes.Mode = CipherMode.CBC;
 				tdes.Padding = PaddingMode.None;
 
 				// normalize key - generated key is 32 bytes long, we need 24 bytes to encrypt

--- a/security/PrivacyAES.cs
+++ b/security/PrivacyAES.cs
@@ -13,14 +13,16 @@
 // You should have received a copy of the GNU General Public License
 // along with SNMP#NET.  If not, see <http://www.gnu.org/licenses/>.
 // 
+#if !NETCOREAPP11 && !NETSTANDARD15
 using System;
 using System.Security.Cryptography;
 using System.Net;
 
 namespace SnmpSharpNet
 {
-	/// <summary>AES privacy protocol implementation class.</summary>
-	public class PrivacyAES : IPrivacyProtocol
+
+    /// <summary>AES privacy protocol implementation class.</summary>
+    public class PrivacyAES : IPrivacyProtocol
 	{
 		/// <summary>
 		/// Salt value
@@ -319,3 +321,4 @@ namespace SnmpSharpNet
 		}
 	}
 }
+#endif

--- a/security/PrivacyAES128.cs
+++ b/security/PrivacyAES128.cs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with SNMP#NET.  If not, see <http://www.gnu.org/licenses/>.
 // 
+#if !NETCOREAPP11 && !NETSTANDARD15
 
 namespace SnmpSharpNet
 {
@@ -41,3 +42,4 @@ namespace SnmpSharpNet
 		}
 	}
 }
+#endif

--- a/security/PrivacyAES192.cs
+++ b/security/PrivacyAES192.cs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with SNMP#NET.  If not, see <http://www.gnu.org/licenses/>.
 // 
+#if !NETCOREAPP11 && !NETSTANDARD15
 
 namespace SnmpSharpNet
 {
@@ -42,3 +43,4 @@ namespace SnmpSharpNet
 		}
 	}
 }
+#endif

--- a/security/PrivacyAES256.cs
+++ b/security/PrivacyAES256.cs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with SNMP#NET.  If not, see <http://www.gnu.org/licenses/>.
 // 
+#if !NETCOREAPP11 && !NETSTANDARD15
 
 namespace SnmpSharpNet
 {
@@ -42,3 +43,4 @@ namespace SnmpSharpNet
 		}
 	}
 }
+#endif

--- a/security/PrivacyDES.cs
+++ b/security/PrivacyDES.cs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with SNMP#NET.  If not, see <http://www.gnu.org/licenses/>.
 // 
+#if !NETCOREAPP11 && !NETSTANDARD15
 using System;
 using System.Security.Cryptography;
 
@@ -328,3 +329,4 @@ namespace SnmpSharpNet
 		}
 	}
 }
+#endif

--- a/security/PrivacyProtocol.cs
+++ b/security/PrivacyProtocol.cs
@@ -44,7 +44,8 @@ namespace SnmpSharpNet
 		{
 			if (privProtocol == PrivacyProtocols.None)
 				return null;
-			else if (privProtocol == PrivacyProtocols.DES)
+#if !NETCOREAPP11 && !NETSTANDARD15
+            else if (privProtocol == PrivacyProtocols.DES)
 				return new PrivacyDES();
 			else if (privProtocol == PrivacyProtocols.AES128)
 				return new PrivacyAES128();
@@ -52,6 +53,7 @@ namespace SnmpSharpNet
 				return new PrivacyAES192();
 			else if (privProtocol == PrivacyProtocols.AES256)
 				return new PrivacyAES256();
+#endif
 			else if (privProtocol == PrivacyProtocols.TripleDES)
 				return new Privacy3DES();
 			return null;

--- a/security/UserSecurityModel.cs
+++ b/security/UserSecurityModel.cs
@@ -24,8 +24,11 @@ namespace SnmpSharpNet
 	/// <summary>
 	/// User security model implementation class.
 	/// </summary>
-	public class UserSecurityModel : AsnType, ICloneable
-	{
+	public class UserSecurityModel : AsnType
+#if !NETCOREAPP11 && !NETSTANDARD15
+        , ICloneable
+#endif
+    {
 		/// <summary>
 		/// Authoritative engine id
 		/// </summary>


### PR DESCRIPTION
I've added project files to build this library for .NETCore 1.2 and .NETStandard 1.5. While porting I've dropped support for Privacy* classes except for 3DES (AES implementation has slightly different parameters in newer framework, I'm not sure if it would work well and I don't have SNMP server with security to test it; DES is really obsolete and insecure).

Project is prepared for publication on nuget, just run `dotnet pack SnmpSharpNet-Std.sln` and it will generate package for publishing.