### PR TITLE
Trim trailing NULLs

### DIFF
--- a/AsnType.cs
+++ b/AsnType.cs
@@ -161,6 +161,8 @@ namespace SnmpSharpNet
 			{
 				// short form encoding
 				dataLen = mb[offset++];
+				if (dataLen > mb.Length - (offset))
+					dataLen = mb.Length - (offset);
 				return dataLen; // we are done
 			}
 			else

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -15,5 +15,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("33f5795a-9f55-4965-89bc-0f413452bd0f")]
 
-[assembly: AssemblyVersion("0.9.5")]
-[assembly: AssemblyFileVersion("0.9.5")]
+[assembly: AssemblyVersion("0.9.6")]
+[assembly: AssemblyFileVersion("0.9.6")]

--- a/UdpTarget.cs
+++ b/UdpTarget.cs
@@ -205,6 +205,15 @@ namespace SnmpSharpNet
 			{
 				throw new SnmpException(SnmpException.NoDataReceived, "No data received on request.");
 			}
+			
+			Debug.Print($"Buffer length: {inBuffer.Length}");
+			byte[] tempBuffer = inBuffer;
+			int i = tempBuffer.Length -1;
+			while (tempBuffer[i] == 0x00)
+				--i;
+			if(i+2 < inBuffer.Length)
+				Array.Resize(ref inBuffer, i + 1);
+			Debug.Print($"Buffer length: {inBuffer.Length}");
 			// verify packet
 			if (agentParameters.Version == SnmpVersion.Ver1)
 			{

--- a/UdpTarget.cs
+++ b/UdpTarget.cs
@@ -206,14 +206,14 @@ namespace SnmpSharpNet
 				throw new SnmpException(SnmpException.NoDataReceived, "No data received on request.");
 			}
 			
-			Debug.Print($"Buffer length: {inBuffer.Length}");
+			//Debug.Print($"Buffer length: {inBuffer.Length}");
 			byte[] tempBuffer = inBuffer;
 			int i = tempBuffer.Length -1;
-			while (tempBuffer[i] == 0x00)
+			while (tempBuffer[i-1] == 0x00 && tempBuffer[i] == 0x00)
 				--i;
-			if(i+2 < inBuffer.Length)
+			if(i + 1 < inBuffer.Length)
 				Array.Resize(ref inBuffer, i + 1);
-			Debug.Print($"Buffer length: {inBuffer.Length}");
+			//Debug.Print($"Buffer length: {inBuffer.Length}");
 			// verify packet
 			if (agentParameters.Version == SnmpVersion.Ver1)
 			{


### PR DESCRIPTION
A certain broadcast equipment manufacturers has started packing OctetStrings with NULLs to the full length of the packet, leading to decode errors.  This removes trailing NULLs from the input buffer and recalculates the offset if required.
I will leave a single trailing null if needed